### PR TITLE
Add ability to move orthogonality center

### DIFF
--- a/src/mps.jl
+++ b/src/mps.jl
@@ -29,7 +29,7 @@ function set_orthogonality(m::MPS, site::Integer)
     end
 
     if site == curr_orthogonality_site
-        return
+        return m
     end
 
     if site > curr_orthogonality_site

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -21,7 +21,7 @@ end
     Moves the orthogonality center.
 """
 function set_orthogonality(m::MPS, site::Integer)
-    sites = m.sites
+    sites = copy(m.sites)
     curr_orthogonality_site = m.orthogonality_site
     N = length(m.sites)
     if !(site in 1:N)
@@ -40,7 +40,10 @@ function set_orthogonality(m::MPS, site::Integer)
             left_edge_dim = first(size(active_site))
             active_size = size(active_site)
             L, Q = lq(reshape(active_site, left_edge_dim, :))
-            sites[i] = reshape(Q, active_size...)
+            if first(size(L)) < first(size(Q))
+                Q = Q[1:first(size(L)), :]
+            end
+            sites[i] = convert(Array{Float64}, reshape(Q, active_size...))
             if i < N
                 next = sites[i+1]
                 @einsum updated[χ_l, q, χ_r] := next[χ_l, q, χ] * L[χ, χ_r]

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -35,7 +35,7 @@ function set_orthogonality(m::MPS, site::Integer)
     if site > curr_orthogonality_site
         # Move O.C. from right to left
         # i = curr, curr + 1, curr + 2, etc. <--
-        for i = curr_orthogonality_site:site
+        for i = curr_orthogonality_site:site-1
             active_site = sites[i]
             left_edge_dim = first(size(active_site))
             active_size = size(active_site)
@@ -55,7 +55,8 @@ function set_orthogonality(m::MPS, site::Integer)
         end
     else
         # Move O.C. from left to right
-        for i = curr_orthogonality_site:-1:site
+        # i = curr, curr - 1, curr - 2, etc. -->
+        for i = curr_orthogonality_site:-1:site+1
             active_site = sites[i]
             right_edge_dim = last(size(active_site))
             active_size = size(active_site)
@@ -67,6 +68,10 @@ function set_orthogonality(m::MPS, site::Integer)
             if i > 1
                 next = sites[i-1]
                 @einsum updated[χ_l, q, χ_r] := R[χ_l, χ] * next[χ, q, χ_r]
+                # Squash (n X n X 1) -> (n X n) for edge
+                if i == 2
+                    updated = reshape(updated, size(updated)[1:2]...)
+                end
                 sites[i-1] = updated
             else
                 sites[i] = active_site

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -43,7 +43,7 @@ function set_orthogonality(m::MPS, site::Integer)
             if first(size(L)) < first(size(Q))
                 Q = Q[1:first(size(L)), :]
             end
-            sites[i] = convert(Array{Float64}, reshape(Q, active_size...))
+            sites[i] = convert(Array{}, reshape(Q, active_size...))
             next = sites[i+1]
             if i != N - 1
                 @einsum updated[χ_l, q, χ_r] := next[χ_l, q, χ] * L[χ, χ_r]
@@ -63,7 +63,7 @@ function set_orthogonality(m::MPS, site::Integer)
             if last(size(R)) < last(size(Q))
                 Q = Q[:, 1:last(size(R))]
             end
-            sites[i] = convert(Array{Float64}, reshape(Q, active_size...))
+            sites[i] = convert(Array{}, reshape(Q, active_size...))
             next = sites[i-1]
             @einsum updated[χ_l, q, χ_r] := R[χ_l, χ] * next[χ, q, χ_r]
             # Squash (n X n X 1) -> (n X n) for edge

--- a/src/tebd.jl
+++ b/src/tebd.jl
@@ -20,11 +20,12 @@ end
     Performs block evolution from left to right.
 """
 function block_evolve(ψ::MPS, H::Hamiltonian, t::Number)
+    N = length(ψ.sites)
+    ψ = set_orthogonality(ψ, N)
     updated_sites::Array{Array{<:Number}} = []
     interaction = reshape(exp(H.interaction * t), 2, 2, 2, 2)
     field = exp(H.field * t)
     half_field = exp(H.field * t / 2)
-    N = length(ψ.sites)
     # Left to Right
     local previous_right_site::Array{<:Number}
     for i = N-1:-1:1

--- a/src/tebd.jl
+++ b/src/tebd.jl
@@ -83,7 +83,7 @@ function block_evolve(ψ::MPS, H::Hamiltonian, t::Number)
             push!(updated_sites, reshape(new_right_site, size(right_site)...))
         end
     end
-    return MPS(reverse(updated_sites), ψ.bond_dim)
+    return MPS(reverse(updated_sites), ψ.bond_dim, 1)
 end
 
 end # module

--- a/test/mps_test.jl
+++ b/test/mps_test.jl
@@ -14,6 +14,37 @@ using .MatrixProductState
         catch err
         end
         @test err isa DomainError
+        A = zeros(2, 2, 2)
+        A_mps = mps(A)
+        err = nothing
+        try
+            A_mps = set_orthogonality(A_mps, 4)
+        catch err
+        end
+        @test err isa DomainError
+        A = reshape(
+            [
+                0.464654 0.594944
+                0.0734789 0.514704
+                0.118756 0.799922
+                0.142388 0.622209
+                0.0820784 0.245697
+                0.143912 0.291454
+                0.967784 0.382256
+                0.273797 0.880877
+            ],
+            2,
+            2,
+            2,
+            2,
+        )
+        A_mps = mps(A)
+        B_mps = mps(A)
+        for i = 1:3
+            A_mps = set_orthogonality(A_mps, i)
+            @test round.(contract_mps(A_mps), digits = 5) ==
+                  round.(contract_mps(B_mps), digits = 5)
+        end
     end
     @testset "Orthogonality Center" begin
         # Output should be entirely right normal except for last site
@@ -26,14 +57,14 @@ using .MatrixProductState
         A_mps = mps(A)
         middle_site = A_mps.sites[2]
         @einsum res[i, j] := middle_site[i, a, b] * middle_site[j, a, b]
-        @test round.(res, digits=10) == [1 0; 0 1]
+        @test round.(res, digits = 10) == [1 0; 0 1]
 
-        A = rand((2 for _=1:10)...)
+        A = rand((2 for _ = 1:10)...)
         A_mps = mps(A)
-        for i=2:9
+        for i = 2:9
             site = A_mps.sites[i]
             @einsum res[i, j] := site[i, a, b] * site[j, a, b]
-            @test round.(res, digits=7) == [1 0; 0 1]
+            @test round.(res, digits = 7) == [1 0; 0 1]
         end
     end
     @testset "Contraction" begin

--- a/test/mps_test.jl
+++ b/test/mps_test.jl
@@ -1,6 +1,5 @@
 using Einsum
 using LinearAlgebra
-using Debugger
 using Test
 
 include("../src/mps.jl")

--- a/test/mps_test.jl
+++ b/test/mps_test.jl
@@ -123,7 +123,53 @@ using .MatrixProductState
         site = D_mps.sites[2]
         @einsum res[i,j] := site[i, a, b] * site[j, a, b]
         @test round.(res, digits = 8) == [1 0; 0 1]
-
+        # D:
+        # >-.-<-<
+        # | | | |
+        #
+        # E:
+        # >->-.-<
+        # | | | |
+        E_mps = set_orthogonality(D_mps, 2)
+        # Test numerical stability: safe up to approx. 12 digits
+        @test round.(contract_mps(A_mps), digits = 12) ==
+              round.(contract_mps(D_mps), digits = 12)
+        @test round.(contract_mps(A_mps), digits = 12) ==
+              round.(contract_mps(E_mps), digits = 12)
+        @test A_mps.sites != E_mps.sites
+        @test D_mps.sites != E_mps.sites
+        # Left and right edge 2-leg tensors
+        for i in [1, 4]
+            res = E_mps.sites[i] * transpose(E_mps.sites[i])
+            @test round.(res, digits = 8) == [1 0; 0 1]
+        end
+        # Second from left left-normal 3-leg tensor
+        site = E_mps.sites[3]
+        @einsum res[i,j] := site[a, b, i] * site[a, b, j]
+        @test round.(res, digits = 8) == [1 0; 0 1]
+        # D:
+        # >-.-<-<
+        # | | | |
+        #
+        # F:
+        # .-<-<-<
+        # | | | |
+        F_mps = set_orthogonality(D_mps, 4)
+        # Test numerical stability: safe up to approx. 12 digits
+        @test round.(contract_mps(A_mps), digits = 12) ==
+              round.(contract_mps(D_mps), digits = 12)
+        @test round.(contract_mps(A_mps), digits = 12) ==
+              round.(contract_mps(F_mps), digits = 12)
+        @test D_mps.sites != F_mps.sites
+        # Ensure each right-normal site in B is actually right-normal
+        #     Middle 3-leg tensors
+        for i=2:3
+            site = F_mps.sites[i]
+            @einsum res[i,j] := site[i, a, b] * site[j, a, b]
+            @test round.(res, digits = 8) == [1 0; 0 1]
+        end
+        res = F_mps.sites[1] * transpose(F_mps.sites[1])
+        @test round.(res, digits = 8) == [1 0; 0 1]
     end
     @testset "Contraction" begin
         # First simple test

--- a/test/mps_test.jl
+++ b/test/mps_test.jl
@@ -22,6 +22,28 @@ using .MatrixProductState
         catch err
         end
         @test err isa DomainError
+    end
+    @testset "Orthogonality Center" begin
+        # Output should be entirely right normal except for last site
+        A = ones(2, 2, 2)
+        A[1, 1, 1] = 0
+        A[1, 2, 2] = 0
+        A[2, 1, 2] = 0
+        A[2, 2, 1] = 0
+        A[1, 1, 2] = 2
+        A_mps = mps(A)
+        middle_site = A_mps.sites[2]
+        @einsum res[i, j] := middle_site[i, a, b] * middle_site[j, a, b]
+        @test round.(res, digits = 10) == [1 0; 0 1]
+
+        A = rand((2 for _ = 1:10)...)
+        A_mps = mps(A)
+        for i = 2:9
+            site = A_mps.sites[i]
+            @einsum res[i, j] := site[i, a, b] * site[j, a, b]
+            @test round.(res, digits = 7) == [1 0; 0 1]
+        end
+        # Moving the orthogonality center
         A = reshape(
             [
                 0.464654 0.594944
@@ -102,27 +124,6 @@ using .MatrixProductState
         @einsum res[i,j] := site[i, a, b] * site[j, a, b]
         @test round.(res, digits = 8) == [1 0; 0 1]
 
-    end
-    @testset "Orthogonality Center" begin
-        # Output should be entirely right normal except for last site
-        A = ones(2, 2, 2)
-        A[1, 1, 1] = 0
-        A[1, 2, 2] = 0
-        A[2, 1, 2] = 0
-        A[2, 2, 1] = 0
-        A[1, 1, 2] = 2
-        A_mps = mps(A)
-        middle_site = A_mps.sites[2]
-        @einsum res[i, j] := middle_site[i, a, b] * middle_site[j, a, b]
-        @test round.(res, digits = 10) == [1 0; 0 1]
-
-        A = rand((2 for _ = 1:10)...)
-        A_mps = mps(A)
-        for i = 2:9
-            site = A_mps.sites[i]
-            @einsum res[i, j] := site[i, a, b] * site[j, a, b]
-            @test round.(res, digits = 7) == [1 0; 0 1]
-        end
     end
     @testset "Contraction" begin
         # First simple test

--- a/test/mps_test.jl
+++ b/test/mps_test.jl
@@ -41,9 +41,10 @@ using .MatrixProductState
         A_mps = mps(A)
         B_mps = mps(A)
         for i = 1:3
-            A_mps = set_orthogonality(A_mps, i)
+            B_mps = set_orthogonality(A_mps, i)
             @test round.(contract_mps(A_mps), digits = 5) ==
                   round.(contract_mps(B_mps), digits = 5)
+            @test A_mps.sites != B_mps.sites
         end
     end
     @testset "Orthogonality Center" begin

--- a/test/mps_test.jl
+++ b/test/mps_test.jl
@@ -75,9 +75,9 @@ using .MatrixProductState
         @test A_mps.sites != B_mps.sites
         # Ensure each left-normal site in B is actually left-normal
         #     Middle 3-leg tensors
-        for i=2:3
+        for i = 2:3
             site = B_mps.sites[i]
-            @einsum res[i,j] := site[a, b, i] * site[a, b, j]
+            @einsum res[i, j] := site[a, b, i] * site[a, b, j]
             @test round.(res, digits = 8) == [1 0; 0 1]
         end
         # Left edge 2-leg tensor
@@ -101,7 +101,7 @@ using .MatrixProductState
         end
         # Second from left left-normal 3-leg tensor
         site = C_mps.sites[3]
-        @einsum res[i,j] := site[a, b, i] * site[a, b, j]
+        @einsum res[i, j] := site[a, b, i] * site[a, b, j]
         @test round.(res, digits = 8) == [1 0; 0 1]
         # A:
         # .-<-<-<
@@ -121,7 +121,7 @@ using .MatrixProductState
         end
         # Second from right right-normal 3-leg tensor
         site = D_mps.sites[2]
-        @einsum res[i,j] := site[i, a, b] * site[j, a, b]
+        @einsum res[i, j] := site[i, a, b] * site[j, a, b]
         @test round.(res, digits = 8) == [1 0; 0 1]
         # D:
         # >-.-<-<
@@ -145,7 +145,7 @@ using .MatrixProductState
         end
         # Second from left left-normal 3-leg tensor
         site = E_mps.sites[3]
-        @einsum res[i,j] := site[a, b, i] * site[a, b, j]
+        @einsum res[i, j] := site[a, b, i] * site[a, b, j]
         @test round.(res, digits = 8) == [1 0; 0 1]
         # D:
         # >-.-<-<
@@ -163,13 +163,46 @@ using .MatrixProductState
         @test D_mps.sites != F_mps.sites
         # Ensure each right-normal site in B is actually right-normal
         #     Middle 3-leg tensors
-        for i=2:3
+        for i = 2:3
             site = F_mps.sites[i]
-            @einsum res[i,j] := site[i, a, b] * site[j, a, b]
+            @einsum res[i, j] := site[i, a, b] * site[j, a, b]
             @test round.(res, digits = 8) == [1 0; 0 1]
         end
         res = F_mps.sites[1] * transpose(F_mps.sites[1])
         @test round.(res, digits = 8) == [1 0; 0 1]
+
+        # Bigger random test
+        rank = 10
+        A = rand(ComplexF64, (2 for _ = 1:rank)...)
+        A_mps = mps(A)
+        B_mps = set_orthogonality(A_mps, 2)
+        right_edge = B_mps.sites[1]
+        @test round.(right_edge * conj(transpose(right_edge)), digits = 8) == [1 0; 0 1]
+        for i = 3:9
+            site = B_mps.sites[i]
+            conjugate = conj.(site)
+            @einsum res[i, j] := site[a, b, i] * conjugate[a, b, j]
+            @test round.(res, digits = 8) == [1 0; 0 1]
+        end
+        C_mps = set_orthogonality(B_mps, 7)
+        for i in [1, 10]
+            edge = B_mps.sites[i]
+            @test round.(edge * conj(transpose(edge)), digits = 8) == [1 0; 0 1]
+        end
+        # Right normal sites
+        for i = 2:6
+            site = C_mps.sites[i]
+            conjugate = conj.(site)
+            @einsum res[i, j] := conjugate[i, a, b] * site[j, a, b]
+            @test round.(res, digits = 8) == [1 0; 0 1]
+        end
+        # Left normal sites
+        for i = 8:9
+            site = C_mps.sites[i]
+            conjugate = conj.(site)
+            @einsum res[i, j] := site[a, b, i] * conjugate[a, b, j]
+            @test round.(res, digits = 8) == [1 0; 0 1]
+        end
     end
     @testset "Contraction" begin
         # First simple test

--- a/test/mps_test.jl
+++ b/test/mps_test.jl
@@ -1,3 +1,4 @@
+using Einsum
 using LinearAlgebra
 using Test
 
@@ -13,6 +14,27 @@ using .MatrixProductState
         catch err
         end
         @test err isa DomainError
+    end
+    @testset "Orthogonality Center" begin
+        # Output should be entirely right normal except for last site
+        A = ones(2, 2, 2)
+        A[1, 1, 1] = 0
+        A[1, 2, 2] = 0
+        A[2, 1, 2] = 0
+        A[2, 2, 1] = 0
+        A[1, 1, 2] = 2
+        A_mps = mps(A)
+        middle_site = A_mps.sites[2]
+        @einsum res[i, j] := middle_site[i, a, b] * middle_site[j, a, b]
+        @test round.(res, digits=10) == [1 0; 0 1]
+
+        A = rand((2 for _=1:10)...)
+        A_mps = mps(A)
+        for i=2:9
+            site = A_mps.sites[i]
+            @einsum res[i, j] := site[i, a, b] * site[j, a, b]
+            @test round.(res, digits=7) == [1 0; 0 1]
+        end
     end
     @testset "Contraction" begin
         # First simple test


### PR DESCRIPTION
Adds the ability to non-destructively move the orthogonality center of the MPS using `set_orthogonality`. Tested on complex tensors up to (tensor)rank 10. Added call to `set_orthogonality` to `block_evolve` to ensure `block_evolve` can be called multiple times.