### PR TITLE
Fix `eval_local_op`

### DIFF
--- a/src/mps.jl
+++ b/src/mps.jl
@@ -84,7 +84,12 @@ function eval_local_op(m::MPS, M::Array{<:Number}, site::Integer)
     m = set_orthogonality(m, site)
     ψ = m.sites[site]
     conj_ψ = conj.(ψ)
-    @einsum res := ψ[χ_l, α, χ_r] * M[α, β] * conj_ψ[χ_l, β, χ_r]
+    local res
+    if site < length(m.sites)
+        @einsum res := ψ[χ_l, α, χ_r] * M[α, β] * conj_ψ[χ_l, β, χ_r]
+    else
+        @einsum res := ψ[α, χ] * M[α, β] * conj_ψ[β, χ]
+    end
     return res
 end
 

--- a/test/mps_test.jl
+++ b/test/mps_test.jl
@@ -250,9 +250,30 @@ using .MatrixProductState
         σ_z = [1 0; 0 -1]
         I = [1 0; 0 1]
         conj_tensor = conj.(A_mps_tensor)
+        
+        @einsum full_res :=
+            A_mps_tensor[a, b, c, d, α] * σ_z[α, β] * conj_tensor[a, b, c, d, β]
+        easy_res = eval_local_op(A_mps, σ_z, 1)
+        @test round(easy_res, digits = 12) == round(full_res, digits = 12)
+
+        @einsum full_res :=
+            A_mps_tensor[a, b, c, α, d] * σ_z[α, β] * conj_tensor[a, b, c, β, d]
+        easy_res = eval_local_op(A_mps, σ_z, 2)
+        @test round(easy_res, digits = 12) == round(full_res, digits = 12)
+
         @einsum full_res :=
             A_mps_tensor[a, b, α, c, d] * σ_z[α, β] * conj_tensor[a, b, β, c, d]
         easy_res = eval_local_op(A_mps, σ_z, 3)
+        @test round(easy_res, digits = 12) == round(full_res, digits = 12)
+
+        @einsum full_res :=
+            A_mps_tensor[a, α, b, c, d] * σ_z[α, β] * conj_tensor[a, α, b, c, d]
+        easy_res = eval_local_op(A_mps, σ_z, 4)
+        @test round(easy_res, digits = 12) == round(full_res, digits = 12)
+
+        @einsum full_res :=
+            A_mps_tensor[α, a, b, c, d] * σ_z[α, β] * conj_tensor[α, a, b, c, d]
+        easy_res = eval_local_op(A_mps, σ_z, 5)
         @test round(easy_res, digits = 12) == round(full_res, digits = 12)
     end
 end


### PR DESCRIPTION
Previously had insufficient test coverage. Einsum was squashing indices incorrectly for the last site in the chain, leading to incorrect behavior as seen in the tebd example notebook. This should fix that.